### PR TITLE
Potential fix for code scanning alert no. 14: Double escaping or unescaping

### DIFF
--- a/src/services/generative/provider/generate.algorithm.service.ts
+++ b/src/services/generative/provider/generate.algorithm.service.ts
@@ -172,10 +172,10 @@ function preprocessContent(content: string, contentType: string): string {
       return content
         .replace(/<[^>]*>/g, ' ')
         .replace(/&nbsp;/g, ' ')
-        .replace(/&amp;/g, '&')
         .replace(/&lt;/g, '<')
         .replace(/&gt;/g, '>')
         .replace(/&quot;/g, '"')
+        .replace(/&amp;/g, '&')
         .replace(/\s+/g, ' ')
         .trim();
 


### PR DESCRIPTION
Potential fix for [https://github.com/perinst/dozu-api-service/security/code-scanning/14](https://github.com/perinst/dozu-api-service/security/code-scanning/14)

To fix the issue, the decoding of `&amp;` should be moved to the end of the `.replace()` chain in the `webpage` case of the `preprocessContent` function. This ensures that ampersands are decoded only after all other entities have been processed, preventing double unescaping. No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
