### PR TITLE
Potential fix for code scanning alert no. 13: Insecure configuration of Helmet security middleware

### DIFF
--- a/src/config/middlewares/helmet.config.ts
+++ b/src/config/middlewares/helmet.config.ts
@@ -7,7 +7,16 @@ import { config } from '../env.config';
  */
 const helmetConfig = () => {
   return helmet({
-    contentSecurityPolicy: config.isProduction ? undefined : false,
+    contentSecurityPolicy: config.isProduction
+      ? undefined
+      : {
+          directives: {
+            "default-src": ["'self'"],
+            "script-src": ["'self'", "'unsafe-inline'"],
+            "style-src": ["'self'", "'unsafe-inline'"],
+            "img-src": ["'self'", "data:"],
+          },
+        },
     crossOriginEmbedderPolicy: config.isProduction,
     hidePoweredBy: true,
     hsts: config.isProduction,


### PR DESCRIPTION
Potential fix for [https://github.com/perinst/dozu-api-service/security/code-scanning/13](https://github.com/perinst/dozu-api-service/security/code-scanning/13)

To fix the issue, we will replace the `contentSecurityPolicy` configuration to ensure that CSP is not disabled entirely. Instead of setting it to `false` in non-production environments, we will provide a relaxed CSP configuration for development while keeping the default or a stricter CSP configuration for production. This ensures that CSP is always enabled, reducing the risk of injection attacks.

The changes will involve:
1. Updating the `contentSecurityPolicy` configuration to use a relaxed policy in non-production environments.
2. Keeping the default or stricter CSP configuration for production environments.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
