### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/aws.pipeline.yml
+++ b/.github/workflows/aws.pipeline.yml
@@ -1,5 +1,8 @@
 name: AWS EC2 CI/CD Pipeline
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/perinst/dozu-api-service/security/code-scanning/7](https://github.com/perinst/dozu-api-service/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the workflow. This block will be added at the root level to apply to all jobs unless overridden by job-specific `permissions` blocks. Based on the workflow's operations, the minimal required permissions are:
- `contents: read` for accessing repository contents (e.g., during the `build` job).
- No write permissions are required since the workflow does not modify repository contents or perform actions like creating releases.

We will add the following `permissions` block at the root level:
```yaml
permissions:
  contents: read
```

This ensures that the `GITHUB_TOKEN` has only read access to repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
