### PR TITLE
Potential fix for code scanning alert no. 160: Type confusion through parameter tampering

### DIFF
--- a/src/controllers/uploads/upload.file.controller.ts
+++ b/src/controllers/uploads/upload.file.controller.ts
@@ -64,9 +64,12 @@ class UploadFileController {
    */
   public async uploadMultipleFiles(req: Request, res: Response): Promise<void> {
     try {
-      const files = req.files as Express.Multer.File[];
-      if (!files || files.length === 0) {
-        throw new BadRequest('No files uploaded');
+      const files = req.files;
+      if (
+        !Array.isArray(files) ||
+        files.some(file => !(file && typeof file === 'object' && 'originalname' in file && 'path' in file))
+      ) {
+        throw new BadRequest('Invalid files uploaded');
       }
 
       // Process the uploaded files

--- a/src/services/uploads/files/upload.file.service.ts
+++ b/src/services/uploads/files/upload.file.service.ts
@@ -309,11 +309,18 @@ export class UploadFileService {
    * @param _userId - Optional user ID (unused but kept for future extension)
    */
   public async processMultipleFiles(
-    files: Express.Multer.File[],
+    files: unknown,
     _userId?: string
   ): Promise<MultipleFileUploadResult> {
     const successful: FileUploadResult[] = [];
     const failed: Array<{ originalName: string; error: string }> = [];
+    if (
+      !Array.isArray(files) ||
+      files.some(file => !(file && typeof file === 'object' && 'originalname' in file && 'path' in file))
+    ) {
+      throw new BadRequest('Invalid files array');
+    }
+
     for (const file of files) {
       try {
         const result = await this.processSingleFile(file, _userId);


### PR DESCRIPTION
Potential fix for [https://github.com/perinst/dozu-api-service/security/code-scanning/160](https://github.com/perinst/dozu-api-service/security/code-scanning/160)

To fix the issue, we need to validate the type of `req.files` in the `uploadMultipleFiles` method of `upload.file.controller.ts`. Specifically:
1. Ensure that `req.files` is an array and that all its elements are of type `Express.Multer.File`.
2. If the validation fails, throw a `BadRequest` error to prevent further processing.

This fix ensures that only properly formatted arrays of `Express.Multer.File` objects are passed to the `processMultipleFiles` method, mitigating the risk of type confusion.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
