### PR TITLE
feat(admin): add user management and stats APIs

### DIFF
--- a/src/controllers/admin/auth.controller.ts
+++ b/src/controllers/admin/auth.controller.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from 'express';
+import { SuccessResponse } from '@/core/success';
+import { adminAuthService } from '@/services/admin/auth.service';
+
+class AdminAuthController {
+  constructor() {}
+
+  async handleGetUserAuthAccounts(req: Request, res: Response) {
+    const userId = Number(req.params.id);
+    const result = await adminAuthService.getAuthAccounts(userId);
+    SuccessResponse.ok(res, result, 'Fetched linked accounts successfully');
+  }
+}
+
+export const adminAuthController = new AdminAuthController();

--- a/src/controllers/admin/user.controller.ts
+++ b/src/controllers/admin/user.controller.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from 'express';
+import { adminUserService } from '@/services/admin/user.service';
+import { SuccessResponse } from '@/core/success';
+class AdminUserController {
+    constructor() {}
+
+    async handleGetAllUsers(req: Request, res: Response) {
+        const users = await adminUserService.getAllUsers(req.query);
+        SuccessResponse.ok(res, users, 'Fetched users successfully');
+    };
+
+    async handleToggleUserActive(req: Request, res: Response) {
+        const {id} = req.params;
+        const updatedUser = await adminUserService.tonggleUserActive(Number(id));
+        SuccessResponse.ok(res, updatedUser, 'Toggled user active state successfully');
+    };
+
+    async handleUpdateUserRole(req: Request, res: Response) {
+        const {id} = req.params;
+        const result = await adminUserService.updateUserRole(Number(id), req.body);
+        SuccessResponse.ok(res, result, 'Updated user role successfully');
+    };
+
+    async handleGetUserStats(req: Request, res: Response) {
+        const result = await adminUserService.getUserStats();
+        SuccessResponse.ok(res, result, 'Fetched user statistics');
+    };
+}
+
+export const adminUserController = new AdminUserController();

--- a/src/dtos/admin/getUsers.dto.ts
+++ b/src/dtos/admin/getUsers.dto.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+const booleanString = z.enum(['true', 'false']).transform(val => val === 'true');
+
+export const getUsersQuerySchema = z.object({
+  role: z.enum(['user', 'admin']).optional(),
+  isActive: booleanString.optional(),
+  isVerified: booleanString.optional(),
+  hasCompletedOnboarding: booleanString.optional(),
+});
+
+export type GetUsersQueryDto = z.infer<typeof getUsersQuerySchema>;

--- a/src/dtos/admin/updateUserRole.dto.ts
+++ b/src/dtos/admin/updateUserRole.dto.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const updateUserRoleSchema = z.object({
+  role: z.enum(['user', 'admin']),
+});
+
+export type UpdateUserRoleDto = z.infer<typeof updateUserRoleSchema>;

--- a/src/middleware/validations/admin/user.validation.ts
+++ b/src/middleware/validations/admin/user.validation.ts
@@ -1,0 +1,15 @@
+import validateData from '@/middleware/validations/validator';
+import { getUsersQuerySchema } from '@/dtos/admin/getUsers.dto';
+import { updateUserRoleSchema } from '@/dtos/admin/updateUserRole.dto';
+
+export const validateGetUsersQuery = () =>
+  validateData({
+    selector: (req) => req.query,
+    schema: getUsersQuerySchema,
+  });
+
+export const validateUpdateUserRole = () =>
+  validateData({
+    selector: req => req.body,
+    schema: updateUserRoleSchema,
+  });

--- a/src/repositories/admin/auth.repo.ts
+++ b/src/repositories/admin/auth.repo.ts
@@ -1,0 +1,16 @@
+import  db  from '@/libs/drizzleClient.lib';
+import { authAccountsTable } from '@/models/auth/authAccount.model';
+import { eq } from 'drizzle-orm';
+
+class AdminAuthRepo {
+  constructor() {}
+
+  async getAuthAccountsByUserId(userId: number) {
+    return await db
+      .select()
+      .from(authAccountsTable)
+      .where(eq(authAccountsTable.userId, userId));
+  }
+}
+
+export const adminAuthRepo = new AdminAuthRepo();

--- a/src/repositories/admin/user.repo.ts
+++ b/src/repositories/admin/user.repo.ts
@@ -1,0 +1,55 @@
+import  db from '@/libs/drizzleClient.lib';
+import { usersTable } from '@/models/user.model';
+import { eq, count } from 'drizzle-orm';
+
+class AdminUserRepo {
+  constructor() {}
+
+  async getUserById(userId: number) {
+    const user = await db.select().from(usersTable).where(eq(usersTable.userId, userId)).limit(1);
+    return user[0];
+  };
+
+  async updateUserActive(userId: number, isActive: boolean) {
+    const updated = await db
+      .update(usersTable)
+      .set({ isActive })
+      .where(eq(usersTable.userId, userId))
+      .returning();
+    return updated[0];
+  };
+
+  async updateUserRole(userId: number, role: 'user' | 'admin') {
+    const updated = await db
+      .update(usersTable)
+      .set({ role })
+      .where(eq(usersTable.userId, userId))
+      .returning();
+    return updated[0];
+  };
+
+  async countUserStats() {
+    const [total] = await db.select({ value: count() }).from(usersTable);
+    const [active] = await db.select({ value: count() }).from(usersTable).where(eq(usersTable.isActive, true));
+    const [verified] = await db.select({ value: count() }).from(usersTable).where(eq(usersTable.isVerified, true));
+    const [onboarded] = await db
+      .select({ value: count() })
+      .from(usersTable)
+      .where(eq(usersTable.hasCompletedOnboarding, true));
+    const [newUsers] = await db
+      .select({ value: count() })
+      .from(usersTable)
+      .where(eq(usersTable.isNewUser, true));
+
+    return {
+      total: total.value,
+      active: active.value,
+      verified: verified.value,
+      onboarded: onboarded.value,
+      newUsers: newUsers.value,
+    };
+  };
+
+}
+
+export const adminUserRepo = new AdminUserRepo();

--- a/src/routes/admin/admin.routes.ts
+++ b/src/routes/admin/admin.routes.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import { globalAsyncHandler } from '@/middleware/handler/handler.v2';
+import { registerRoute } from '@/routes/register.routes';
+import { authMiddleware } from '@/middleware/auth.middleware';
+import { adminUserController } from '@/controllers/admin/user.controller';
+import { adminAuthController } from '@/controllers/admin/auth.controller';
+import { validateGetUsersQuery, validateUpdateUserRole } from '@/middleware/validations/admin/user.validation';
+
+const router = Router();
+globalAsyncHandler(router);
+// router.use(authMiddleware);
+
+router.get('/', validateGetUsersQuery(), adminUserController.handleGetAllUsers);
+router.patch('/:id/toggle-active',adminUserController.handleToggleUserActive);
+router.patch('/:id/role', validateUpdateUserRole(), adminUserController.handleUpdateUserRole);
+router.get('/:id/auth-accounts', adminAuthController.handleGetUserAuthAccounts);
+router.get('/user-stats', adminUserController.handleGetUserStats);
+
+registerRoute('/admin/users', router, {
+  description: 'Admin API',
+  version: 'v1',
+  isEnabled: true,
+});
+
+export const adminUserRoutes = router;

--- a/src/routes/api.routes.ts
+++ b/src/routes/api.routes.ts
@@ -16,6 +16,7 @@ import './auth/auth.routes';
 import './recommendation/recommendation.routes';
 import './schedule/schedule.routes';
 import './uploads/upload.routes';
+import './admin/admin.routes'
 
 // Apply global async handler to router
 globalAsyncHandler(router);

--- a/src/services/admin/auth.service.ts
+++ b/src/services/admin/auth.service.ts
@@ -1,0 +1,16 @@
+import { adminAuthRepo } from '@/repositories/admin/auth.repo';
+import { adminUserRepo } from '@/repositories/admin/user.repo';
+import { NotFoundError } from '@/core/error';
+
+class AdminAuthService {
+  constructor() {}
+
+  async getAuthAccounts(userId: number) {
+    const user = await adminUserRepo.getUserById(userId);
+    if(!user) throw new NotFoundError('User not found');
+
+    return await adminAuthRepo.getAuthAccountsByUserId(userId);
+  }
+}
+
+export const adminAuthService = new AdminAuthService();

--- a/src/services/admin/user.service.ts
+++ b/src/services/admin/user.service.ts
@@ -1,0 +1,49 @@
+import  db from '@/libs/drizzleClient.lib';
+import {usersTable} from '@/models/user.model';
+import { eq, and } from 'drizzle-orm';
+import { NotFoundError } from '@/core/error';
+import { GetUsersQueryDto } from '@/dtos/admin/getUsers.dto';
+import { adminUserRepo } from '@/repositories/admin/user.repo';
+import { UpdateUserRoleDto } from '@/dtos/admin/updateUserRole.dto';
+class AdminUserService {
+    constructor() {}
+
+    async getAllUsers(filters: GetUsersQueryDto) {
+        const {role, isActive, isVerified, hasCompletedOnboarding} = filters;
+        const conditions = [];
+
+        if (role) conditions.push(eq(usersTable.role, role));
+        if (isActive !== undefined) conditions.push(eq(usersTable.isActive, isActive));
+        if (isVerified !== undefined) conditions.push(eq(usersTable.isVerified, isVerified));
+        if (hasCompletedOnboarding !== undefined)
+           conditions.push(eq(usersTable.hasCompletedOnboarding, hasCompletedOnboarding));
+
+        const users = await db.select().from(usersTable).where(and(...conditions));
+
+        return users;
+    };
+
+    async tonggleUserActive(userId: number) {
+        const user = await adminUserRepo.getUserById(userId);
+        if(!user) throw new NotFoundError('User not found');
+
+        const updated = await adminUserRepo.updateUserActive(userId, !user.isActive);
+        return updated;
+    };
+
+    async updateUserRole(userId: number, payload: UpdateUserRoleDto) {
+        const user = await adminUserRepo.getUserById(userId);
+        if (!user) throw new NotFoundError('User not found');
+
+        return await adminUserRepo.updateUserRole(userId, payload.role);
+    };
+
+    async getUserStats() {
+        return await adminUserRepo.countUserStats();
+    };
+
+
+    
+}
+
+export const adminUserService = new AdminUserService;


### PR DESCRIPTION
This Pull Request adds a set of user management features for the admin panel, including:

1. User listing

Displays a list of users in the system.

Supports filtering by role, active status, verification status, and onboarding completion.

2. User role update

Allows admins to change the role of a specific user (between user and admin).

3. Toggle user active status

Enables toggling a user’s active status (activate/deactivate).

4. View linked login accounts (OAuth)

Shows a list of third-party accounts linked by the user (Google, GitHub, ...).

5. User statistics overview

Returns summarized figures: total users, active users, verified users, onboarded users, and newly registered users.

