### PR TITLE
Potential fix for code scanning alert no. 184: Type confusion through parameter tampering

### DIFF
--- a/src/controllers/uploads/upload.file.controller.ts
+++ b/src/controllers/uploads/upload.file.controller.ts
@@ -85,13 +85,13 @@ class UploadFileController {
      */
     public async uploadMultipleFiles(req: Request, res: Response): Promise<void> {
         try {
-            const files = req.files as Express.Multer.File[];
-            if (!files || files.length === 0) {
-                throw new BadRequest('No files uploaded');
+            const files = req.files;
+            if (!Array.isArray(files) || files.length === 0) {
+                throw new BadRequest('No files uploaded or malformed files parameter');
             }
 
             // Process the uploaded files
-            const result = await uploadFileService.processMultipleFiles(files);
+            const result = await uploadFileService.processMultipleFiles(files as Express.Multer.File[]);
 
             logger.info(`Multiple files upload completed: ${result.successCount}/${result.totalFiles} successful`);
 


### PR DESCRIPTION
Potential fix for [https://github.com/perinst/dozu-api-service/security/code-scanning/184](https://github.com/perinst/dozu-api-service/security/code-scanning/184)

The correct fix is to perform a runtime type check on `files` immediately after assignment from `req.files` in the controller (`uploadMultipleFiles`). Specifically, before using any array operations (like `.length` or `for ... of`), ensure that `files` is an array and not a string or other unexpected type. If the check fails, throw a `BadRequest` error. 

Change the following in `src/controllers/uploads/upload.file.controller.ts`:
- In `uploadMultipleFiles`, after assigning `const files = req.files as Express.Multer.File[];`, check that `files` is an array using `Array.isArray(files)`.
- If not, throw a `BadRequest` with a message like 'Malformed files parameter'.
- Optionally, narrow the cast (remove `as Express.Multer.File[]` from the assignment; cast after the check for type safety).

This ensures the downstream code (`processMultipleFiles`) receives a real array only, preventing type confusion and abuse.

No changes are required in the service; the controller will now guarantee the type for the service.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced upload handling with stricter validation to ensure at least one valid file is provided before processing.
  - Displays a clearer error message when no files are uploaded or when the upload payload is malformed, replacing ambiguous failures.
  - Improves reliability and user guidance for multi-file submissions by preventing invalid requests from proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->