### PR TITLE
stage(core): debug IMAGE and TAG are empty in deploy

### DIFF
--- a/.github/workflows/vietnix.dockerhub.pipeline.yml
+++ b/.github/workflows/vietnix.dockerhub.pipeline.yml
@@ -66,7 +66,6 @@ jobs:
               run: |
                   set -euo pipefail
                   IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/dozu-api-service"
-                  # sanitize branch (replace / with -)
                   BRANCH_TAG="${BRANCH_INPUT//\//-}"
                   SHORT_SHA="${GITHUB_SHA::7}"
                   TAG="${ENV_INPUT}-${BRANCH_TAG}-${SHORT_SHA}"
@@ -186,6 +185,10 @@ jobs:
               run: |
                   sudo apt-get update
                   sudo apt-get install -y sshpass
+            - name: Debug image/tag from previous job
+              run: |
+                  echo "IMAGE=${{ needs.build-push.outputs.image }}"
+                  echo "TAG=${{ needs.build-push.outputs.tag }}"
 
             - name: Pull image and restart container
               env:
@@ -202,7 +205,7 @@ jobs:
                   set -e
                   # login to Docker Hub
                   if command -v docker >/dev/null 2>&1; then
-                    echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USER" --password-stdin --quiet || true
+                    echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USER" --password-stdin || true
                   fi
                   # pull latest image
                   docker pull "$IMAGE:$TAG" || { echo "docker pull failed"; exit 1; }


### PR DESCRIPTION
…uts.* not populated or not referenced correctly).

docker login --quiet isn’t supported on your remote Docker (older version). Remote doesn’t receive DOCKER_USER/DOCKER_TOKEN/IMAGE/TAG (variables aren’t passed into the remote shell).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced deployment pipeline logging to aid troubleshooting during Docker image pushes.
  - Added a debug step to display the generated image name and tag after build/push.
  - Increased visibility of Docker login output to simplify diagnosing authentication issues.
  - No changes to application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->