### PR TITLE
feat(auth): refactor code, refresh token

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -3,21 +3,45 @@ import { SuccessResponse } from '@/core/success';
 import {
     googleOAuthLoginService,
     loginService,
+    refreshTokenService,
     registerUserService,
     verifyEmailService,
 } from '@/services/auth.service';
 
 import { AuthenticationError, BadRequest } from '@/core/error';
-import { signAccessJwtToken, signRefreshJwtToken } from '@/utils/auth/jwt.utils';
+import { signAccessJwtToken } from '@/utils/auth/jwt.utils';
 import { sanitizeUserObject } from '@/utils/auth/authHelpers.utils';
-import jwt from 'jsonwebtoken';
 
 const frontEndBaseUrl = process.env.FRONTEND_BASE_URL;
-const SECRET = process.env.JWT_SECRET;
 
 export const testingAuthPath = async (req: Request, res: Response) => {
     // const data = await handleServiceDemo(req.body);
     SuccessResponse.ok(res, { message: 'Auth running' });
+};
+
+export const loginController = async (req: Request, res: Response) => {
+    if (!req.body.username || !req.body.password) {
+        throw new BadRequest('Both username and password are required');
+    }
+    const username = req.body.username;
+    const password = req.body.password;
+    const data = await loginService({ username, password });
+    if (!data.success) {
+        throw new AuthenticationError(data.reason);
+    }
+
+    res.cookie('refreshToken', data.refreshToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+    });
+
+    const returnData = {
+        ...data.user,
+        isNewUser: false, //technically business logic, can move to service
+        accessToken: data.accessToken,
+    };
+    SuccessResponse.ok(res, returnData);
 };
 
 export const registerUserController = async (req: Request, res: Response) => {
@@ -36,42 +60,6 @@ export const registerUserController = async (req: Request, res: Response) => {
     SuccessResponse.created(res, returnData);
 };
 
-export const loginController = async (req: Request, res: Response) => {
-    if (!req.body.username || !req.body.password) {
-        throw new BadRequest('Both username and password are required');
-    }
-
-    const username = req.body.username;
-    const password = req.body.password;
-    const data = await loginService(username, password);
-    if (!data.success) {
-        throw new AuthenticationError(data.reason);
-    }
-    if (!data.user.isActive) {
-        //checks if user is banned
-        throw new AuthenticationError('Account is disabled');
-    }
-    //add cookie and more
-    const sanitizedUser = sanitizeUserObject(data.user);
-    const accessToken = signAccessJwtToken(sanitizedUser);
-    const refreshToken = signRefreshJwtToken(sanitizedUser);
-
-    res.cookie('refreshToken', refreshToken, {
-        // httpOnly: true,
-        // secure: false, // ❌ Set to true in production (HTTPS)
-        // sameSite: 'none',
-    });
-
-    const returnData = {
-        ...sanitizedUser,
-        isNewUser: false,
-        refreshToken,
-        accessToken,
-    };
-
-    SuccessResponse.ok(res, returnData);
-};
-
 export const logoutController = async (req: Request, res: Response) => {
     //?Consider blacklist if more security is wanted
     res.clearCookie('refreshToken');
@@ -79,30 +67,21 @@ export const logoutController = async (req: Request, res: Response) => {
 };
 
 export const refreshTokenController = async (req: Request, res: Response) => {
-    //?Consider blacklist if more security is wanted
-    //todo:delete refresh token when it is implemented
     const refreshToken = req.cookies.refreshToken;
-    if (!SECRET) {
-        throw new Error('JWT_SECRET is not defined in environment variables');
-    }
     if (!refreshToken) {
-        throw new BadRequest('Refresh token is required');
+        throw new AuthenticationError('Refresh token does not exist');
     }
-    try {
-        const decoded: any = jwt.verify(refreshToken, SECRET);
-
-        const sanitizedUser = sanitizeUserObject(decoded.user);
-        //.verify Validates expiration by default
-        //todo: enforce type for decoded
-        //todo: requery by userId
-        const accessToken = signAccessJwtToken(sanitizedUser);
-        const returnData: any = sanitizedUser;
-        returnData.accessToken = accessToken;
+    const refreshTokenServiceData = await refreshTokenService({refreshToken:refreshToken});
+    if (!refreshTokenServiceData.success) {
+        throw new AuthenticationError(refreshTokenServiceData.reason);
+    } else {
+        const returnData = {
+            user: refreshTokenServiceData.user,
+            isNewUser: false,
+            accessToken: refreshTokenServiceData.accessToken,
+        };
         SuccessResponse.ok(res, returnData);
-    } catch {
-        throw new BadRequest('Unauthorized: Invalid token');
     }
-    // SuccessResponse.ok(res, {}); //todo:check if empty data is ok
 };
 
 export const verifyEmailController = async (req: Request, res: Response) => {
@@ -125,9 +104,11 @@ export const verifyEmailController = async (req: Request, res: Response) => {
 };
 
 export const getProfileController = async (req: Request, res: Response) => {
-    const returnData: any = sanitizeUserObject(req.currentUser);
+    // const returnData: any = sanitizeUserObject(req.currentUser?.user);
 
-    SuccessResponse.ok(res, returnData);
+    // todo - implement logic for getting new data here
+
+    SuccessResponse.ok(res, req.currentUser?.user);
 };
 
 export const googleOAuthRedirectController = async (req: Request, res: Response) => {

--- a/src/controllers/generate/v1/generate.controller.ts
+++ b/src/controllers/generate/v1/generate.controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { generateService } from '@/services/generative/v1/generate.service';
-import { BadRequest, InternalServerError } from '@/core/error';
+import { AuthenticationError, BadRequest, InternalServerError } from '@/core/error';
 import { FileUploadRequestInterface } from '@/dtos/generate';
 import { SuccessResponse } from '@/core/success';
 import logger from '@/utils/logger';
@@ -100,6 +100,9 @@ class GenerateController {
      */
     public async generateMindmapFromText(req: Request, res: Response): Promise<void> {
         const { content, customPrompt, type } = req.body;
+         if (!req.currentUser) {
+            throw new AuthenticationError('Login information is invalid');
+        }
         const { userId } = req.currentUser;
 
         if (!content) {

--- a/src/controllers/payment/payment.controller.ts
+++ b/src/controllers/payment/payment.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequest } from '@/core/error';
+import { AuthenticationError, BadRequest } from '@/core/error';
 import { SuccessResponse } from '@/core/success';
 import { paymentService } from '@/services/payment/payment.service';
 import { sepayWebhookService } from '@/services/payment/sepay-webhook.service';
@@ -15,6 +15,9 @@ export const PREFIX_KEY_SSE_SEPAY = 'PAYMENT-SEPAY-SSE-WEBHOOK';
  */
 class PaymentController {
     async createLinkPaymentWithPayOS(req: Request, res: Response) {
+         if (!req.currentUser) {
+            throw new AuthenticationError('Login information is invalid');
+        }
         const userId = req.currentUser.userId;
         const timeZone = getTimezoneClient(req);
         const paymentData = req.body;
@@ -29,13 +32,16 @@ class PaymentController {
             ...paymentData,
             userId,
             planId,
-            timeZone
+            timeZone,
         });
 
         SuccessResponse.created(res, paymentLink);
     }
 
     async createLinkPaymentWithSepay(req: Request, res: Response) {
+        if (!req.currentUser) {
+            throw new AuthenticationError('Login information is invalid');
+        }
         const userId = req.currentUser.userId;
         const timeZone = getTimezoneClient(req);
         const paymentData = req.body;

--- a/src/controllers/profile/profile.controller.ts
+++ b/src/controllers/profile/profile.controller.ts
@@ -1,18 +1,18 @@
-import { Response } from 'express';
+import { Request,Response } from 'express';
 import { SuccessResponse } from '@/core/success';
 import ProfileService from '@/services/profile/profile.service';
 import type { AuthenticatedRequest } from '@/types/profile/profile.types';
 
 class ProfileController {
   // Get user profile
-   public async getProfile(req: AuthenticatedRequest, res: Response): Promise<void> {
+   public async getProfile(req: Request, res: Response): Promise<void> {
     const userId = req.currentUser!.userId;
     const profile = await ProfileService.getProfile(parseInt(userId));
     SuccessResponse.ok(res, profile);
   }
 
   // Update user profile
-  async updateProfile(req: AuthenticatedRequest, res: Response): Promise<void> {
+  async updateProfile(req: Request, res: Response): Promise<void> {
     const userId = req.currentUser!.userId;
     const updatedProfile = await ProfileService.updateProfile(parseInt(userId), req.body);
     SuccessResponse.ok(res, updatedProfile, 'Profile updated successfully');
@@ -21,7 +21,7 @@ class ProfileController {
   // Upload avatar
 
   // Change password
-   async changePassword(req: AuthenticatedRequest, res: Response): Promise<void> {
+   async changePassword(req: Request, res: Response): Promise<void> {
     const userId = req.currentUser!.userId;
 
     await ProfileService.changePassword(parseInt(userId), req.body);
@@ -29,7 +29,7 @@ class ProfileController {
   }
 
   // Update notification settings
-  async updateNotificationSettings(req: AuthenticatedRequest, res: Response): Promise<void> {
+  async updateNotificationSettings(req: Request, res: Response): Promise<void> {
     const userId = req.currentUser!.userId;
 
     const settings = await ProfileService.updateNotificationSettings(parseInt(userId), req.body);
@@ -37,7 +37,7 @@ class ProfileController {
   }
 
   // Update privacy settings
-  async updatePrivacySettings(req: AuthenticatedRequest, res: Response): Promise<void> {
+  async updatePrivacySettings(req: Request, res: Response): Promise<void> {
     const userId = req.currentUser!.userId;
 
     const settings = await ProfileService.updatePrivacySettings(parseInt(userId), req.body);
@@ -45,7 +45,7 @@ class ProfileController {
   }
 
   // Update user settings (combined notification and privacy)
-  async updateSettings(req: AuthenticatedRequest, res: Response): Promise<void> {
+  async updateSettings(req: Request, res: Response): Promise<void> {
     const userId = req.currentUser!.userId;
 
     const settings = await ProfileService.updateSettings(parseInt(userId), req.body);
@@ -53,7 +53,7 @@ class ProfileController {
   }
 
   // Delete account
-  async deleteAccount(req: AuthenticatedRequest, res: Response): Promise<void> {
+  async deleteAccount(req: Request, res: Response): Promise<void> {
     const userId = req.currentUser!.userId;
 
     await ProfileService.deleteAccount(parseInt(userId));

--- a/src/controllers/tracking/tracking.controller.ts
+++ b/src/controllers/tracking/tracking.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import { trackingService } from '@/services/tracking/tracking.service';
 import { SuccessResponse } from '@/core/success';
-import { BadRequest } from '@/core/error';
+import { AuthenticationError, BadRequest } from '@/core/error';
 
 /**
  * Controller class for Tracking functionality
@@ -13,6 +13,9 @@ class TrackingController {
      * @param res - Express response object
      */
     public async getCurrentLearningTopicProgressTracking(req: Request, res: Response): Promise<void> {
+        if (!req.currentUser) {
+            throw new AuthenticationError('Login information is invalid');
+        }
         const { userId } = req.currentUser;
 
         if (isNaN(userId) || userId <= 0) {
@@ -32,6 +35,9 @@ class TrackingController {
      * @param res - Express response object
      */
     public async requestTrackingTimeLearningActive(req: Request, res: Response): Promise<void> {
+         if (!req.currentUser) {
+            throw new AuthenticationError('Login information is invalid');
+        }
         const { userId } = req.currentUser;
 
         if (isNaN(userId) || userId <= 0) {

--- a/src/global/types/express/index.d.ts
+++ b/src/global/types/express/index.d.ts
@@ -1,10 +1,11 @@
+import { DecodedTokenPayload } from '@/types/auth/jwtPayload.type';
 import { IClass } from '@/types/class-based-learning/class.type';
 import { ITopic } from '@/types/topic/topic.type';
 
 declare global {
     namespace Express {
         interface Request {
-            currentUser?: any;
+            currentUser?: DecodedTokenPayload;
             validated?: {
                 params?: {
                     classId?: number;

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -4,8 +4,9 @@ import { NextFunction, Request, Response } from 'express';
 
 import jwt from 'jsonwebtoken';
 import logger from '@/utils/logger';
-import { BadRequest, Forbidden } from '@/core/error';
+import { AuthenticationError, BadRequest, Forbidden } from '@/core/error';
 import { getUserRolesFromRequest } from '@/utils/auth/authHelpers.utils';
+import { DecodedTokenPayload } from '@/types/auth/jwtPayload.type';
 
 const SECRET = process.env.JWT_SECRET; // make sure to use env vars in production
 
@@ -14,13 +15,14 @@ export const authMiddleware = async (req: Request, res: Response, next: NextFunc
     const accessToken = authHeader && authHeader.split(' ')[1]; // Bearer <token>
 
     if (!accessToken) {
-        throw new BadRequest('Access token is required');
+        throw new AuthenticationError('Access token is required');
     }
     if (!SECRET) {
         throw new Error('JWT_SECRET is not defined in environment variables');
     }
 
     try {
+        console.log(accessToken, 'accessTOken');
         const decoded: any = jwt.verify(accessToken, SECRET);
         //.verify Validates expiration by default
 
@@ -30,63 +32,65 @@ export const authMiddleware = async (req: Request, res: Response, next: NextFunc
     } catch (error) {
         console.log(error);
         logger.warn('Invalid token');
-        throw new BadRequest('Unauthorized: Invalid token');
+        throw new AuthenticationError('Unauthorized: Invalid token');
     }
 };
 
 export const validateStudent = async (req: Request, res: Response, next: NextFunction) => {
     const roles = await getUserRolesFromRequest(req);
     const isStudent = roles.length === 1 && roles[0].name === 'user';
-    if(isStudent) {
+    if (isStudent) {
         next();
     } else {
         const message = 'Forbidden: Require Student role to access the resources';
         logger.warn(message);
         throw new Forbidden(message);
     }
-}
+};
 
 export const validateTeacher = async (req: Request, res: Response, next: NextFunction) => {
     const roles = await getUserRolesFromRequest(req);
-    const isTeacher = roles.find((role) => role.name === 'teacher');
-    if(isTeacher) {
+    const isTeacher = roles.find(role => role.name === 'teacher');
+    if (isTeacher) {
         next();
     } else {
         const message = 'Forbidden: Require teacher to access the resources';
         logger.warn(message);
         throw new Forbidden(message);
     }
-}
+};
 
 export const validateAdmin = async (req: Request, res: Response, next: NextFunction) => {
     const roles = await getUserRolesFromRequest(req);
-    const isAdmin = roles.find((role) => role.name === 'admin');
-    if(isAdmin) {
+    const isAdmin = roles.find(role => role.name === 'admin');
+    if (isAdmin) {
         next();
     } else {
         const message = 'Forbidden: Require admin to access the resources';
         logger.warn(message);
         throw new Forbidden(message);
     }
-}
+};
 
 export const authMiddlewareIfHeadersPresent = async (req: Request, res: Response, next: NextFunction) => {
+    //todo - DuyND: What the fuck, reread again later.
     const authHeader = req.headers['authorization'];
     const accessToken = authHeader && authHeader.split(' ')[1]; // Bearer <token>
 
     if (!accessToken) {
-        next();//skips verifying if user is not logged in, for use with endpoints where you can optionally use as guest - DuyND
+        next(); //skips verifying if user is not logged in, for use with endpoints where you can optionally use as guest - DuyND
     } else if (!SECRET) {
         throw new Error('JWT_SECRET is not defined in environment variables');
     } else {
         try {
-            const decoded: any = jwt.verify(accessToken, SECRET);
+            const decoded = jwt.verify(accessToken, SECRET) as DecodedTokenPayload;
             //.verify Validates expiration by default
 
             req.currentUser = decoded; // add `user` to Request via type augmentation
 
             next();
         } catch (error) {
+            //!remove console.log with proper logger
             console.log(error);
             logger.warn('Invalid token');
             throw new BadRequest('Unauthorized: Invalid token');

--- a/src/middleware/auth.middleware.ts
+++ b/src/middleware/auth.middleware.ts
@@ -22,7 +22,6 @@ export const authMiddleware = async (req: Request, res: Response, next: NextFunc
     }
 
     try {
-        console.log(accessToken, 'accessTOken');
         const decoded: any = jwt.verify(accessToken, SECRET);
         //.verify Validates expiration by default
 
@@ -30,8 +29,7 @@ export const authMiddleware = async (req: Request, res: Response, next: NextFunc
 
         next();
     } catch (error) {
-        console.log(error);
-        logger.warn('Invalid token');
+        logger.warn('Invalid token', error);
         throw new AuthenticationError('Unauthorized: Invalid token');
     }
 };

--- a/src/routes/auth/auth.routes.ts
+++ b/src/routes/auth/auth.routes.ts
@@ -28,6 +28,8 @@ router.post('/refresh-token',refreshTokenController)
 router.get('/verify-email', verifyEmailController);
 router.get('/profile', authMiddleware, getProfileController);
 router.post('/google', googleOAuthRedirectController);
+//todo - Duy: missing forget password flow: /forget-password to begin, /reset-password to go through with new password
+//todo - Duy: consider resend verification flow or remove verification flow
 
 registerRoute('/auth', router, {
   description: 'Authentication endpoints',

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,3 +1,4 @@
+import { InternalServerError } from '@/core/error';
 import { getOAuthToken } from '@/libs/googleOAuth2Client';
 import { sendVerificationLinkEmail } from '@/libs/nodeMailerTransporter.lib';
 import { InsertAuthAccount } from '@/models';
@@ -19,25 +20,101 @@ import {
     updateLastLoginAt,
     updateUserIsVerified,
 } from '@/repositories/auth.repo';
+import { DecodedTokenPayload } from '@/types/auth/jwtPayload.type';
+import { SanitizedUser } from '@/types/auth/sanitizedUser.type';
+import { sanitizeUserObject } from '@/utils/auth/authHelpers.utils';
 import { hashPassword, verifyPassword } from '@/utils/auth/hash.utils';
-import { decodeJwtToken } from '@/utils/auth/jwt.utils';
+import { decodeJwtToken, signAccessJwtToken, signRefreshJwtToken } from '@/utils/auth/jwt.utils';
+import jwt from 'jsonwebtoken';
+
+const SECRET = process.env.JWT_SECRET;
 
 // type for getLoginData response
 export interface UserLoginDataResponse extends SelectUser {
     roles: string[];
     permissions?: string[]; // optional, implement in the future
-}  
+}
+
+type LoginResult2 =
+    | { success: true; user: SanitizedUser; accessToken: string; refreshToken: string }
+    | { success: false; reason: string }; //todo:reformat as template type for every services
 
 type LoginResult = { success: true; user: UserLoginDataResponse } | { success: false; reason: string }; //todo:reformat as template type for every services
 
-const getLoginData = async (userId: number) : Promise<UserLoginDataResponse> => {
+type RefreshTokenResult =
+    | { success: true; user: SanitizedUser; accessToken: string }
+    | { success: false; reason: string };
+
+export const loginService = async ({
+    username,
+    password,
+}: {
+    username: string;
+    password: string;
+}): Promise<LoginResult2> => {
+    const userData = await selectOneUserByUsername(username);
+    if (!userData) return { success: false, reason: 'Username does not exist' };
+    if (!userData.passwordHash) return { success: false, reason: 'Password is not set up' };
+
+    const isCorrectPassword = await verifyPassword(password, userData.passwordHash);
+    if (!userData.isActive) {
+        //checks if user is banned
+        return { success: false, reason: 'Account is inactive' };
+    } else if (isCorrectPassword) {
+        const updatedUser = await getLoginData(userData.userId);
+        const sanitizedUser = sanitizeUserObject(updatedUser);
+
+        const accessToken = signAccessJwtToken(sanitizedUser);
+        const refreshToken = signRefreshJwtToken(sanitizedUser);
+
+        return {
+            success: true,
+            user: sanitizedUser,
+            accessToken,
+            refreshToken,
+        };
+    } else {
+        return { success: false, reason: 'Username or password is not correct' };
+    }
+};
+
+export const refreshTokenService = async ({ refreshToken }: { refreshToken: string }): Promise<RefreshTokenResult> => {
+    if (!SECRET) {
+        throw new InternalServerError('JWT_SECRET is not defined in environment variables');
+    }
+    let decoded: DecodedTokenPayload;
+    try {
+        decoded = jwt.verify(refreshToken, SECRET) as DecodedTokenPayload;
+        //.verify Validates expiration by default
+    } catch (error) {
+        console.log(error);
+        return { success: false, reason: 'refresh token does not exist or is invalid' };
+    }
+
+    //fetch updated user information
+    if (!decoded.user) {
+        return { success: false, reason: 'Password is not set up' };
+    }
+    const userId = decoded.user.userId;
+    const userData = await getLoginData(userId);
+    if (!userData) return { success: false, reason: 'User does not exist' };
+    if (!userData.passwordHash) return { success: false, reason: 'Password is not set up' };
+
+    const sanitizedUser = sanitizeUserObject(userData);
+
+    const accessToken = signAccessJwtToken(sanitizedUser);
+
+    return { success: true, user: sanitizedUser, accessToken: accessToken };
+};
+
+const getLoginData = async (userId: number): Promise<UserLoginDataResponse> => {
     const updatedUser = await updateLastLoginAt(userId);
     const rolesSystem = await getRoles(); //get all roles in system from db
     const userRoleEntries = await getUserRoles(userId); //get all roles of user
     const userRoles = [];
     for (let roleEntry of userRoleEntries) {
         const role = rolesSystem.find(role => role.roleId === roleEntry.roleId);
-        if(role) userRoles.push(role.name); // to not add undefined to the array
+        if (role) userRoles.push(role.name); // to not add undefined to the array
     }
     return { ...updatedUser, roles: userRoles };
 };
@@ -51,24 +128,6 @@ const addRoleUserForAccount = async (userId: number) => {
 export const addRoleTeacherForAccount = async (userId: number) => {
     const teacherRoleId = await getTeacherRoleId();
     await addRole(teacherRoleId, userId);
-}
-
-export const loginService = async (username: string, password: string): Promise<LoginResult> => {
-    const userData = await selectOneUserByUsername(username);
-    if (!userData) return { success: false, reason: 'Username does not exist' };
-    if (!userData.passwordHash) return { success: false, reason: 'Password is not set up' };
-
-    const isCorrectPassword = await verifyPassword(password, userData.passwordHash);
-    if (isCorrectPassword) {
-        const updatedUser = await getLoginData(userData.userId);
-
-        return {
-            success: true,
-            user: updatedUser,
-        };
-    } else {
-        return { success: false, reason: 'Username or password is not correct' };
-    }
 };
 
 //todo:format response with types

--- a/src/types/auth/jwtPayload.type.ts
+++ b/src/types/auth/jwtPayload.type.ts
@@ -1,7 +1,21 @@
+import { JwtPayload } from 'jsonwebtoken';
 import { SanitizedUser } from './sanitizedUser.type';
 
-export interface JwtPayload {
-  user: SanitizedUser;
-  iat: number;
-  exp: number;
+// interface UserPayload {
+//     userId: number;
+//     username: string;
+//     email: string;
+//     fullName: string | null;
+//     avatarUrl: string;
+//     isNewUser: boolean;
+//     hasCompletedOnboarding: boolean;
+//     createdAt: string;
+//     lastLoginAt: string;
+//     permissions: string[];
+//     roles: string[];
+//     isActive: boolean;
+// }
+
+export interface DecodedTokenPayload extends JwtPayload {
+    user: SanitizedUser;//every request from logged in user has to have user object
 }

--- a/src/utils/auth/authHelpers.utils.ts
+++ b/src/utils/auth/authHelpers.utils.ts
@@ -3,6 +3,7 @@ import { SanitizedUser } from '@/types/auth/sanitizedUser.type';
 import { Request } from 'express';
 import { getDateFormatted } from '../date';
 import { UserLoginDataResponse } from '@/services/auth.service';
+import { DecodedTokenPayload } from '@/types/auth/jwtPayload.type';
 
 export const sanitizeUserObject = (userData: UserLoginDataResponse): SanitizedUser => {
     const returnData = {
@@ -25,7 +26,7 @@ export const sanitizeUserObject = (userData: UserLoginDataResponse): SanitizedUs
 
 export const getUserIdFromRequest = (req: Request): number => {
     const user = req.currentUser;
-    let { userId } = user as { userId: string | number };
+    let { userId } = user as DecodedTokenPayload;
     userId = parseInt(userId as string);
     return userId;
 };

--- a/src/utils/auth/jwt.utils.ts
+++ b/src/utils/auth/jwt.utils.ts
@@ -4,7 +4,7 @@ import jwt from 'jsonwebtoken';
 const jwtSecretKey = process.env.JWT_SECRET; //todo:check types better
 
 const expiresIn = 86400; //Seconds until expiration - 86400= 1 day
-const refreshExpiresIn = 604800; //7 days
+const refreshExpiresIn = 2592000; //30 days
 
 type GoogleIdTokenPayload = {
   sub: string;
@@ -60,7 +60,6 @@ export const decodeJwtToken = (token: string): GoogleIdTokenPayload => {
     typeof decoded.sub !== 'string' ||
     typeof decoded.email !== 'string'
   ) {
-    console.log('google token:', token);
     throw new Error('Invalid token payload');
   }
   return decoded as GoogleIdTokenPayload;


### PR DESCRIPTION
Refactored some code in auth controller
Changed error handling in other controllers to ensure typing
Typing changes
Error type changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Refresh-token support with 30-day session persistence; refresh endpoint issues new access tokens. Logout clears the refresh cookie.
  - Login now returns an access token and sets a secure, httpOnly refresh cookie. Registration returns an access token for new users.

- Changes
  - Consistent authentication errors when not logged in.
  - Mindmap generation, payment link creation, and learning tracking now require login.
  - Payment link creation validates plan selection and includes time zone for more reliable processing.
  - Profile retrieval behavior streamlined (no user-facing functionality change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->