### PR TITLE
fix(core): update dependent for stage build image vs build src

### DIFF
--- a/.github/workflows/vietnix.dockerhub.pipeline.yml
+++ b/.github/workflows/vietnix.dockerhub.pipeline.yml
@@ -76,16 +76,18 @@ jobs:
                   if [ -f package.json ] && jq -e '.scripts.build' package.json >/dev/null 2>&1; then
                     npm run build
                   else
-                    echo "No build script"
+                    echo "No build script defined. Failing because build must succeed."
+                    exit 1
                   fi
     build-push:
         name: Build and Push Docker Image
         runs-on: ubuntu-latest
-        needs: check-connection
+        needs: build-source
         outputs:
             # Use base64-encoded outputs to avoid masking by GitHub runner
             image_b64: ${{ steps.meta.outputs.image_b64 }}
             tag_b64: ${{ steps.meta.outputs.tag_b64 }}
+            env_file: ${{ steps.envfile.outputs.env_file }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - CI pipeline now fails when no build script is present, ensuring unsuccessful builds don’t proceed.
  - Adjusted job dependencies to run build steps before image build and push.
  - Propagates an environment file output for downstream steps in the pipeline.
  - Build-and-push step now checks out the specified branch ref, improving consistency across branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->