### PR TITLE
fix(auth): show message if email already registered with password login

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -144,8 +144,10 @@ export const googleOAuthRedirectController = async (req: Request, res: Response)
         };
         SuccessResponse.ok(res, returnData);
     } else {
-        res.redirect(`${frontEndBaseUrl}/auth/login?reason=${data.reason}`);
-        //todo: include message of some kind for FE
+        res.status(409).json({
+            error: 'AUTH_METHOD_CONFLICT',
+            message: 'This email is already registered with password login.',
+        });
     }
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google sign-in now shows a clear, user-friendly message when the email is already registered with password login.
  * Prevents confusing redirects during Google sign-in conflicts; users remain on the sign-in screen with guidance on how to proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->