### PR TITLE
refactor(generate): note important for prompt generate mind map

### DIFF
--- a/src/controllers/generate/v3/generate.controller.ts
+++ b/src/controllers/generate/v3/generate.controller.ts
@@ -9,8 +9,8 @@ import { GenerateContentRequestInterface, JobStatusResponseInterface } from '@/d
 class GenerateController {
     constructor() {}
 
-    async generateContent(req: Request<{}, {}, GenerateContentRequestInterface>, res: Response) {
-        const { content, type } = req.body;
+    async generateContent(req: Request, res: Response) {
+        const { content, type, inputSetId, method } = req.body as GenerateContentRequestInterface;
 
         if (!content) {
             throw new BadRequest('Content is required');
@@ -20,7 +20,7 @@ class GenerateController {
             throw new BadRequest('Type is required');
         }
 
-        const jobInfo = await generativeService.registerGenerateContentByLLM({ content, type });
+        const jobInfo = await generativeService.registerGenerateContentByLLM({ content, type, inputSetId, method });
 
         SuccessResponse.accepted(
             res,

--- a/src/dtos/generate/models/GenerateContentRequestInterface.ts
+++ b/src/dtos/generate/models/GenerateContentRequestInterface.ts
@@ -15,5 +15,8 @@ export type GenerateContentRequestInterface = {
      * Optional method parameter for specifying generation behavior.
      */
     method?: string;
+    /**
+     *
+     */
+    inputSetId?: number | string;
 };
-

--- a/src/utils/prompt/mindmap.prompt.ts
+++ b/src/utils/prompt/mindmap.prompt.ts
@@ -112,10 +112,10 @@ function buildMindmapPromptTemplate(
     } = {}
 ): string {
     const {
-        maxCategories = '3-7',
-        maxSubtopics = '2-4',
-        maxLabelWords = '3-4',
-        contentTruncateLength = 8000,
+        maxCategories = '30',
+        maxSubtopics = '20',
+        maxLabelWords = '10',
+        //contentTruncateLength = 8000,
         isLargeDocument = false,
         customInstructions,
     } = options;
@@ -127,14 +127,13 @@ function buildMindmapPromptTemplate(
     const subtopicCount = isLargeDocument ? '3-5' : maxSubtopics;
     const labelWords = isLargeDocument ? '3-6' : maxLabelWords;
 
-    const truncatedContent = content.substring(0, contentTruncateLength);
-    const contentSuffix =
-        content.length > contentTruncateLength
-            ? isLargeDocument
-                ? '...(content continues - this is a section of a larger document)'
-                : '...(content truncated)'
-            : '';
-
+    // const truncatedContent = content.substring(0, contentTruncateLength);
+    // const contentSuffix =
+    //     content.length > contentTruncateLength
+    //         ? isLargeDocument
+    //             ? '...(content continues - this is a section of a larger document)'
+    //             : '...(content truncated)'
+    //         : '';
 
     return `
 You are an expert at creating ${documentType} mind map from ${isLargeDocument ? 'large ' : ''}documents. Analyze the following content  and create a ${isLargeDocument ? 'detailed' : 'comprehensive'} mindmap structure${isLargeDocument ? ' that captures the main themes and relationships' : ''}.
@@ -162,6 +161,8 @@ IMPORTANT: Return your response as valid JSON that matches this exact structure:
   ]
 }
 
+IMPORTANT: pageStartIndex and pageEndIndex never exceed total page provider by content.
+
 Guidelines${isLargeDocument ? ' for large document mindmaps' : ''}:
 1. Create ${isLargeDocument ? '1 central' : 'a central'} main topic node
 2. Add maximum ${categoryCount} main category nodes connected to the central topic
@@ -174,8 +175,8 @@ ${isLargeDocument ? '8. Position nodes to avoid overlapping' : ''}
 9. Response must be follow language of the content
 10. Each node must have a comprehensive summary of the related content including the overall themes and the major ideas covered.
 
-Content to analyze${isLargeDocument ? ' (truncated for processing)' : ''}:
-${truncatedContent} ${contentSuffix}
+Content to analyze:
+${content}
 
 ${customInstructions ? `Additional Instructions: ${customInstructions}\n\n` : ''}Return only the JSON structure, no additional text or formatting.`;
 }


### PR DESCRIPTION
ISSUE: 
+ https://github.com/perinst/dozu-api-service/issues/240
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now specify an input set and method when generating content.
- Improvements
  - Mindmap generation analyzes full content (no truncation) for more comprehensive results.
  - Expanded output scale: up to 30 categories, 20 subtopics, and 10-word labels.
  - Added guardrails to ensure page index ranges never exceed available content pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->