### PR TITLE
feat(mindmap): add colored edge generation

### DIFF
--- a/src/utils/prompt/mindmap.prompt.ts
+++ b/src/utils/prompt/mindmap.prompt.ts
@@ -158,7 +158,10 @@ IMPORTANT: Return your response as valid JSON that matches this exact structure:
     {
       "id": "unique_edge_id",
       "source": "source_node_id",
-      "target": "target_node_id"
+      "target": "target_node_id",
+      "data":{
+        "color":"#ef4444"
+      }
     }
   ]
 }
@@ -177,6 +180,8 @@ ${isLargeDocument ? '8. Position nodes to avoid overlapping' : ''}
 9. Response must be follow language of the content
 10. Each node must have a comprehensive summary of the related content including the overall themes and the major ideas covered.
 11. Color may be assigned to each node as one of the following strings ['#ef4444', '#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7', '#6b7280'] to the property color inside node data, the provided structure has included a color as an example but root node shouldn't have color, the branches from can have a unifying color to distinguish themselves
+12. Color may be assigned to each edge, in this case, if the target node is colored, the edge should be the same color, the color is specified as property color inside edge data, , the provided structure has included a color as an example 
+13. Each branch should not be more than 3 nodes deep, exceed this if most other branches also need more than 3 nodes
 
 Content to analyze:
 ${content}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mindmap edges now display with colors.
  * Edge colors automatically match their target node colors for visual consistency.
  * Mindmap branches are constrained to a maximum of 3 nodes deep, improving readability in complex maps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->