### PR TITLE
feat(personal_material): update logic for adding sm2 record if a student join a class

### DIFF
--- a/src/controllers/flashcard/flashcard.controller.ts
+++ b/src/controllers/flashcard/flashcard.controller.ts
@@ -1,20 +1,18 @@
 import { BadRequest } from '@/core/error';
 import { SuccessResponse } from '@/core/success';
-import flashcardService, { IFlashcardWithReviewPrediction } from '@/services/flashcard/flashcard.service';
+import flashcardService from '@/services/flashcard/flashcard.service';
 import topicService from '@/services/topic/topic.service';
 import {
     IFlashcard,
     IFlashcardLearningState,
     IFlashcardsBatchInput,
     IFlashcardBatchResult,
-    IDueAnkiCard,
     IAnkiCardReviewed,
 } from '@/types/flashcard/flashcard.type';
 import logger from '@/utils/logger';
 import { Request, Response } from 'express';
-import SuperMemo2, { IQualityResponse } from '@/services/spaced-repetition-system/super-memo-2/superMemo2.service';
 import { getUserIdFromRequest } from '@/utils/auth/authHelpers.utils';
-import { getCurrentDateFromRequest, getCurrentTimestampFromRequest, TimeUnit } from '@/utils/date';
+import { getCurrentTimestampFromRequest, TimeUnit } from '@/utils/date';
 import requestHelper from '@/core/request/request.helper';
 import unsplashLib, { IUnspashImage } from '@/libs/unsplash.lib';
 import AnkiService, {
@@ -90,54 +88,6 @@ class FlashcardController {
         });
 
         SuccessResponse.created(res, {});
-    }
-
-    // !old version: get due flashcards by original SM2 algorithm, replaced by get cards by Anki algorithm
-    public async getDueFlashcardsForTopic(req: Request, res: Response): Promise<void> {
-        const currentDate = getCurrentTimestampFromRequest(req);
-        const userId = getUserIdFromRequest(req);
-        const topicId = requestHelper.getIdParam(req, 'topicId');
-
-        const flashcards = await flashcardService.getDueFlashcardsForTopicAndUser(topicId, userId, currentDate);
-
-        const flashcardsReturned: IFlashcardWithReviewPrediction[] =
-            await flashcardService.getReviewIntervalsByQualityResponses(flashcards);
-
-        SuccessResponse.ok(res, flashcardsReturned);
-    }
-
-    // !old version: review flashcards by old original SM-2 algorithm
-    public async reviewFlashcardByOriginalSM2(req: Request, res: Response): Promise<void> {
-        const userId = getUserIdFromRequest(req);
-        const flashcardId = requestHelper.getIdParam(req, 'flashcardId');
-        const { qualityResponse } = req.body as { qualityResponse: IQualityResponse };
-
-        const flashcard: IFlashcardLearningState =
-            await flashcardService.getSpacedRepetitionDataForFlashcard(flashcardId);
-
-        if (!flashcard) {
-            throw new BadRequest('Flashcard is invalid');
-        }
-        const { reviewInterval, easinessFactor, repetitionNumber } = flashcard;
-        const currentDate = getCurrentDateFromRequest(req);
-
-        const superMemo2 = new SuperMemo2(easinessFactor, reviewInterval, repetitionNumber, qualityResponse);
-        const sm2 = superMemo2.calc();
-
-        const nextReview = SuperMemo2.getNextReview(currentDate, sm2.reviewInterval);
-
-        const sm2Info: Omit<IFlashcardLearningState, 'status'> = {
-            repetitionNumber: sm2.repetitionNumber,
-            easinessFactor: sm2.easinessFactor,
-            reviewInterval: sm2.reviewInterval,
-            lastReviewed: currentDate,
-            nextReview,
-            step: null,
-        };
-
-        await flashcardService.applySM2ToFlashcard(userId, flashcardId, sm2Info);
-
-        SuccessResponse.ok(res, {});
     }
 
     public async searchFlashcardImages(req: Request, res: Response) {
@@ -235,25 +185,7 @@ class FlashcardController {
         const userId = getUserIdFromRequest(req);
         const topicId = requestHelper.getIdParam(req, 'topicId');
 
-        const flashcards = await flashcardService.getDueFlashcardsForTopicAndUser(topicId, userId, currentTimestamp);
-        const ankiSetting = await ankiSettingService.getSettingForTopicAndUser(topicId, userId);
-
-        const result: IDueAnkiCard[] = flashcards.map(card => {
-            return {
-                flashcardId: card.flashcardId,
-                front: card.front,
-                back: card.back,
-                imageUrl: card.imageUrl,
-                topicName: card.topicName,
-                nextReviewDataByRatings: flashcardService.getNextReviewByRatings(
-                    card.flashcardId,
-                    card.learningState!,
-                    ankiSetting
-                ),
-                nextReview: card.learningState!.nextReview,
-                status: card.learningState!.status,
-            };
-        });
+        const result = await flashcardService.getDueAnkiCardsForTopicAndUser(topicId, userId, currentTimestamp);
         SuccessResponse.ok(res, result);
     }
 
@@ -272,25 +204,7 @@ class FlashcardController {
         });
 
         const flashcards = await flashcardService.getFlashcardsForTopic(topicId);
-        const dueFlashcards = await flashcardService.getDueFlashcardsForTopicAndUser(topicId, userId, currentDate);
-        const ankiSetting = await ankiSettingService.getSettingForTopicAndUser(topicId, userId);
-
-        const dueAnkiCards: IDueAnkiCard[] = dueFlashcards.map(card => {
-            return {
-                flashcardId: card.flashcardId,
-                front: card.front,
-                back: card.back,
-                imageUrl: card.imageUrl,
-                topicName: card.topicName,
-                nextReviewDataByRatings: flashcardService.getNextReviewByRatings(
-                    card.flashcardId,
-                    card.learningState!,
-                    ankiSetting
-                ),
-                nextReview: card.learningState!.nextReview,
-                status: card.learningState!.status,
-            };
-        });
+        const dueAnkiCards = await flashcardService.getDueAnkiCardsForTopicAndUser(topicId, userId, currentDate);
 
         SuccessResponse.ok(res, { flashcards, dueAnkiCards });
     }

--- a/src/controllers/topic/topic.controller.ts
+++ b/src/controllers/topic/topic.controller.ts
@@ -8,6 +8,7 @@ import { updateTopicIdOfInputSet } from '@/repositories/inputSet.repo';
 import requestHelper from '@/core/request/request.helper';
 import { deleteImage, uploadImage } from '@/libs/cloudinary.lib';
 import { extractPublicId } from 'cloudinary-build-url';
+import { NotFoundError } from '@/core/error';
 
 class TopicController {
     constructor() {}
@@ -18,6 +19,11 @@ class TopicController {
         const currentDate = getCurrentTimestampFromRequest(req);
 
         const topic: ITopic | undefined = await topicService.getTopicWithCardCounts({ userId, topicId, currentDate });
+
+        if (!topic) {
+            throw new NotFoundError('Topic not found');
+        }
+
         SuccessResponse.ok(res, topic);
     }
 

--- a/src/repositories/topic.repo.ts
+++ b/src/repositories/topic.repo.ts
@@ -54,9 +54,7 @@ class TopicRepo {
         const [result] = await db
             .select({
                 flashcardCounts: {
-                    total: sql<number>`CAST(COUNT(CASE WHEN flashcards.flashcard_id IS NOT NULL THEN 1 END) AS INT)`.as(
-                        'total'
-                    ),
+                    total: sql<number>`CAST(COUNT(*) AS INT)`.as('total'),
                     review: sql<number>`CAST(COUNT(CASE WHEN flashcards.flashcard_id IS NOT NULL AND item_spaced_repetition_tracking.next_review <= ${dueDate} AND item_spaced_repetition_tracking.status = 'review' THEN 1 END) AS INT)`.as(
                         'review'
                     ),
@@ -70,7 +68,7 @@ class TopicRepo {
                 },
             })
             .from(flashcardsTable)
-            .innerJoin(
+            .leftJoin(
                 itemSpacedRepetitionTrackingTable,
                 and(
                     eq(itemSpacedRepetitionTrackingTable.userId, userId),

--- a/src/services/flashcard/flashcard.service.ts
+++ b/src/services/flashcard/flashcard.service.ts
@@ -9,6 +9,7 @@ import {
     IFlashcardUpdateInput,
     IImageSaveInput,
     IFlashcardBatchResult,
+    IDueAnkiCard,
 } from '@/types/flashcard/flashcard.type';
 import { IQualityResponse } from '../spaced-repetition-system/super-memo-2/superMemo2.service';
 import SuperMemo2 from '../spaced-repetition-system/super-memo-2/superMemo2.service';
@@ -22,12 +23,14 @@ import unsplashLib from '@/libs/unsplash.lib';
 import AnkiService, {
     IAnkiCard,
     IAnkiRating,
+    IAnkiStatus,
     IBaseIntervalWithDeviation,
     INextReviewInterval,
     learnAheadLimit,
 } from '../spaced-repetition-system/super-memo-2/anki.service';
 import { addMinutes } from 'date-fns';
 import { IAnkiSetting } from '@/types/anki-setting/ankiSetting.type';
+import ankiSettingService from '../anki-setting/ankiSetting.service';
 
 export type IFlashcardWithReviewPrediction = Pick<
     IFlashcard,
@@ -258,11 +261,11 @@ class FlashcardService {
         await flashcardRepo.applySM2ToFlashcard(userId, flashcardId, sm2);
     }
 
-    public async getDueFlashcardsForTopicAndUser(
+    public async getDueAnkiCardsForTopicAndUser(
         topicId: number,
         userId: number,
         currentDate: string
-    ): Promise<IFlashcard[]> {
+    ): Promise<IDueAnkiCard[]> {
         // serve for Anki algorithm
         const dueDate = addMinutes(new Date(currentDate), learnAheadLimit);
         const allFlashcards = await this.getFlashcardsForTopic(topicId);
@@ -285,13 +288,47 @@ class FlashcardService {
             .filter(e => e !== null) as ICreateTrackingRecord[];
 
         await itemSpacedRepetitionTrackingRepo.initializeTrackingRecords(trackingRecords);
-        
-        const dueFlashcards = await flashcardRepo.getDueFlashcardsForTopicAndUser(
+
+        const dueFlashcards: IFlashcard[] = await flashcardRepo.getDueFlashcardsForTopicAndUser(
             topicId,
             userId,
             dueDate.toISOString()
         );
-        return dueFlashcards;
+
+        const ankiSetting = await ankiSettingService.getSettingForTopicAndUser(topicId, userId);
+        const dueAnkiCards: IDueAnkiCard[] = dueFlashcards.map(card => {
+            return {
+                flashcardId: card.flashcardId,
+                front: card.front,
+                back: card.back,
+                imageUrl: card.imageUrl,
+                topicName: card.topicName,
+                nextReviewDataByRatings: this.getNextReviewByRatings(
+                    card.flashcardId,
+                    card.learningState!,
+                    ankiSetting
+                ),
+                nextReview: card.learningState!.nextReview,
+                status: card.learningState!.status,
+            };
+        });
+
+        const result: IDueAnkiCard[] = [];
+        const { newCardsPerDay, maximumReviewsPerDay } = ankiSetting;
+        let numberOfNewCards = 0,
+            numberOfReviewCards = 0;
+        for (const card of dueAnkiCards) {
+            if (card.status === IAnkiStatus.NEW && numberOfNewCards < newCardsPerDay) {
+                ++numberOfNewCards;
+                result.push(card);
+            }
+            if (card.status === IAnkiStatus.REVIEW && numberOfReviewCards < maximumReviewsPerDay) {
+                ++numberOfReviewCards;
+                result.push(card);
+            }
+        }
+
+        return result;
     }
 
     public async getReviewIntervalsByQualityResponses(

--- a/src/services/flashcard/flashcard.service.ts
+++ b/src/services/flashcard/flashcard.service.ts
@@ -265,8 +265,33 @@ class FlashcardService {
     ): Promise<IFlashcard[]> {
         // serve for Anki algorithm
         const dueDate = addMinutes(new Date(currentDate), learnAheadLimit);
-        const flashcards = await flashcardRepo.getDueFlashcardsForTopicAndUser(topicId, userId, dueDate.toISOString());
-        return flashcards;
+        const allFlashcards = await this.getFlashcardsForTopic(topicId);
+        const allAnkiCards = await this.getAllAnkiCardsForTopic({ userId, topicId });
+
+        // initial tracking record if some flashcards missing its record
+        const trackingRecords = allFlashcards
+            .map(flashcard => {
+                if (allAnkiCards.find(ankiCard => ankiCard.flashcardId === flashcard.flashcardId) !== undefined) {
+                    return null;
+                }
+                return {
+                    userId,
+                    topicId,
+                    itemId: flashcard.flashcardId,
+                    type: 'flashcard',
+                    step: 0,
+                };
+            })
+            .filter(e => e !== null) as ICreateTrackingRecord[];
+
+        await itemSpacedRepetitionTrackingRepo.initializeTrackingRecords(trackingRecords);
+        
+        const dueFlashcards = await flashcardRepo.getDueFlashcardsForTopicAndUser(
+            topicId,
+            userId,
+            dueDate.toISOString()
+        );
+        return dueFlashcards;
     }
 
     public async getReviewIntervalsByQualityResponses(
@@ -342,6 +367,14 @@ class FlashcardService {
 
     public async saveFlashcardImage(image: IImageSaveInput) {
         await unsplashLib.downloadImage(image.downloadLocation);
+    }
+
+    // check if there is any anki card from a topic
+    public async getAllAnkiCardsForTopic({ userId, topicId }: { userId: number; topicId: number }) {
+        // 01/01/2100, trying to get all anki cards including cards that are not due today
+        const future = new Date(2100, 0, 1);
+        const result = await flashcardRepo.getDueFlashcardsForTopicAndUser(topicId, userId, future.toISOString());
+        return result;
     }
 }
 

--- a/src/services/topic/topic.service.ts
+++ b/src/services/topic/topic.service.ts
@@ -6,6 +6,7 @@ import itemSpacedRepetitionTrackingRepo from '@/repositories/tracking/itemSpaced
 import { ICreateTopicBody, ITopic, IUpdateTopicBody } from '@/types/topic/topic.type';
 import { addMinutes } from 'date-fns';
 import { learnAheadLimit } from '../spaced-repetition-system/super-memo-2/anki.service';
+import ankiSettingService from '../anki-setting/ankiSetting.service';
 
 export type ICreateTopicService = ICreateTopicBody & { imageUrl?: string | null };
 export type IUpdateTopicService = IUpdateTopicBody & { imageUrl?: string | null };
@@ -31,7 +32,16 @@ class TopicService {
         currentDate: string;
     }): Promise<ITopic | undefined> {
         const dueDate = addMinutes(new Date(currentDate), learnAheadLimit);
-        const topic = await topicRepo.getTopicWithCardCounts({ userId, topicId, dueDate: dueDate.toISOString() });
+        let topic = await topicRepo.getTopicWithCardCounts({ userId, topicId, dueDate: dueDate.toISOString() });
+
+        if (topic) {
+            const ankiSetting = await ankiSettingService.getSettingForTopicAndUser(topicId, userId);
+            if (topic.flashcardCounts) {
+                topic.flashcardCounts.new = Math.min(topic.flashcardCounts.new, ankiSetting.newCardsPerDay);
+                topic.flashcardCounts.review = Math.min(topic.flashcardCounts.review, ankiSetting.maximumReviewsPerDay);
+            }
+        }
+
         return topic;
     }
 

--- a/src/types/topic/topic.type.ts
+++ b/src/types/topic/topic.type.ts
@@ -1,5 +1,3 @@
-import { IAnkiStatus } from '@/services/spaced-repetition-system/super-memo-2/anki.service';
-
 export interface ITopic {
     topicId: number;
     name: string;
@@ -14,7 +12,12 @@ export interface ITopic {
     hasProgress?: boolean;
 }
 
-export type IFlashcardCounts = Record<Exclude<IAnkiStatus, IAnkiStatus.RELEARNING> | 'total', number>;
+export type IFlashcardCounts = {
+    new: number;
+    learning: number;
+    review: number;
+    total: number;
+};
 
 export type ICreateTopicBody = Pick<ITopic, 'name' | 'description'>;
 export type ICreateTopicResponse = Pick<ITopic, 'topicId' | 'name' | 'description' | 'createdAt' | 'imageUrl'>;


### PR DESCRIPTION
This PR includes updating logic for adding sm2 record if a student join a class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Anki-style due-card handling with per-card next-review data and daily NEW/REVIEW limits.
  * Added an endpoint to fetch all Anki-style cards for a topic.

* **Bug Fixes**
  * Ensured all flashcards initialize tracking records.
  * Included topics without prior tracking data and corrected flashcard count calculations.

* **Breaking Changes**
  * Removed legacy SM2-based review endpoints and replaced them with the Anki-based workflow.
* **Behavior**
  * Missing topics now return a clear "not found" error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->