### PR TITLE
fix(mindmap): changed mindmap prompt 

### DIFF
--- a/src/middleware/subscription/subscript.middleware.ts
+++ b/src/middleware/subscription/subscript.middleware.ts
@@ -143,7 +143,7 @@ class SubscriptionMiddleware {
         });
 
         if (isFeatureExceeded) {
-            // throw new PaymentRequire('You have exceeded your feature usage limit. Please upgrade your subscription.');
+            throw new PaymentRequire('You have exceeded your feature usage limit. Please upgrade your subscription.');
         }
 
         next();

--- a/src/middleware/subscription/subscript.middleware.ts
+++ b/src/middleware/subscription/subscript.middleware.ts
@@ -143,7 +143,7 @@ class SubscriptionMiddleware {
         });
 
         if (isFeatureExceeded) {
-            throw new PaymentRequire('You have exceeded your feature usage limit. Please upgrade your subscription.');
+            // throw new PaymentRequire('You have exceeded your feature usage limit. Please upgrade your subscription.');
         }
 
         next();

--- a/src/utils/prompt/mindmap.prompt.ts
+++ b/src/utils/prompt/mindmap.prompt.ts
@@ -180,11 +180,11 @@ ${'6. Use clear, descriptive labels (' + labelWords + ' words per node)'}
 8. Connect nodes with edges, do not create loop and all nodes must be connected
 9. Response must follow the language of the content
 10. Each node must have a comprehensive summary of the related content including the overall themes and the major ideas covered, stored in the description property of data.
-11. Color may be assigned to each node as one of the following strings ['#ef4444', '#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7', '#6b7280'] to the property color inside node data, the provided structure has included a color as an example but root node shouldn't have color, the branches from can have a unifying color to distinguish themselves
+11. Color may be assigned to each node as one of the following strings ['#ef4444', '#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7', '#6b7280'] to the property color inside node data, the provided structure has included a color as an example but root node shouldn't have color, the branches from it can have a unifying color to distinguish themselves
 12. Color may be assigned to each edge, in this case, if the target node is colored, the edge should be the same color, the color is specified as property color inside edge data, , the provided structure has included a color as an example 
-14. If there are only a few branches, use distinct colors (for example, avoid using '#ef4444', '#f97316' for branches close to each other as they are red and orange, making them blend in with each other). Disregard if there are too many branches.
-15. Consider using only one color for each branch if there are enough colors.
-16. Each child node of a node may include one distinct roadmapOrder with respect to the parent node (meaning for all child nodes of a node, they may be numbered from 0, 1, 2,... and child nodes of another parent node may also be numbered from 0, 1, 2,...) to help visualize learning path, going from 0 to amount of child node of root node minus 1. It's supposed to represent a roadmap so try to keep the node in roughly the chronological order of the original content. Root node should not be included in the roadmap, roadmapOrder here is only shown as a reference.
+13. If there are only a few branches, use distinct colors (for example, avoid using '#ef4444', '#f97316' for branches close to each other as they are red and orange, making them blend in with each other). Disregard if there are too many branches.
+14. Consider using only one color for each branch if there are enough colors.
+15. Each child node of a node may include one distinct roadmapOrder with respect to the parent node (meaning for all child nodes of a node, they may be numbered from 0, 1, 2,... and child nodes of another parent node may also be numbered from 0, 1, 2,...) to help visualize learning path, going from 0 to amount of child node of root node minus 1. It's supposed to represent a roadmap so try to keep the node in roughly the chronological order of the original content. Root node should not be included in the roadmap, roadmapOrder here is only shown as a reference.
 
 
 Content to analyze:

--- a/src/utils/prompt/mindmap.prompt.ts
+++ b/src/utils/prompt/mindmap.prompt.ts
@@ -170,19 +170,22 @@ IMPORTANT: Return your response as valid JSON that matches this exact structure:
 IMPORTANT: pageStartIndex and pageEndIndex never exceed total page provider by content.
 
 Guidelines${isLargeDocument ? ' for large document mindmaps' : ''}:
-1. Create ${isLargeDocument ? '1 central' : 'a central'} main topic node, only this main topic node will have the isRoot property inside data as true, all other nodes will have isRoot:false
+1. Create a central main topic node, only this main topic node will have the isRoot property inside data as true, all other nodes will have isRoot:false
 2. Add maximum ${categoryCount} main category nodes connected to the central topic
 3. Add maximum ${subtopicCount} subtopic nodes for each main category
-4. ${isLargeDocument ? 'Use hierarchical positioning (central -> categories -> subtopics)' : 'Position nodes in a hierarchical layout'}
-${isLargeDocument ? '5. Include cross-references between related concepts' : '5. Ensure all node IDs are unique'}
-${isLargeDocument ? '6. Use clear, descriptive labels (' + labelWords + ' words per node)' : '6. Connect related concepts with edges'}
-${isLargeDocument ? '7. Ensure comprehensive coverage of the document section' : '7. Use clear, concise labels (max ' + labelWords + ' words per node)'}
-${isLargeDocument ? '8. Position nodes to avoid overlapping' : ''}
-9. Response must be follow language of the content
-10. Each node must have a comprehensive summary of the related content including the overall themes and the major ideas covered.
+4. Neither nodes nor edges should ever be empty, ALWAYS INCLUDE BOTH NODES AND EDGES IN RESPONSE
+5. Ensure all node IDs are unique
+${'6. Use clear, descriptive labels (' + labelWords + ' words per node)'}
+7. Ensure comprehensive coverage of the provided content, 
+8. Connect nodes with edges, do not create loop and all nodes must be connected
+9. Response must follow the language of the content
+10. Each node must have a comprehensive summary of the related content including the overall themes and the major ideas covered, stored in the description property of data.
 11. Color may be assigned to each node as one of the following strings ['#ef4444', '#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7', '#6b7280'] to the property color inside node data, the provided structure has included a color as an example but root node shouldn't have color, the branches from can have a unifying color to distinguish themselves
 12. Color may be assigned to each edge, in this case, if the target node is colored, the edge should be the same color, the color is specified as property color inside edge data, , the provided structure has included a color as an example 
-13. Each of the child node of root may include one distinct roadmapOrder to help visualize learning path, going from 0 to amount of child node of root node minus 1. It's supposed to represent a roadmap so try to keep the node in roughly logical learning progression. Root node should not be included in the roadmap, roadmapOrder here is only shown as a reference.
+14. If there are only a few branches, use distinct colors (for example, avoid using '#ef4444', '#f97316' for branches close to each other as they are red and orange, making them blend in with each other). Disregard if there are too many branches.
+15. Consider using only one color for each branch if there are enough colors.
+16. Each child node of a node may include one distinct roadmapOrder with respect to the parent node (meaning for all child nodes of a node, they may be numbered from 0, 1, 2,... and child nodes of another parent node may also be numbered from 0, 1, 2,...) to help visualize learning path, going from 0 to amount of child node of root node minus 1. It's supposed to represent a roadmap so try to keep the node in roughly the chronological order of the original content. Root node should not be included in the roadmap, roadmapOrder here is only shown as a reference.
+
 
 Content to analyze:
 ${content}


### PR DESCRIPTION
changed mindmap prompt to be more conscious of color, reduce error rate(Maybe), and remove some unnecessary parts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized central node phrasing and unified generation rules for consistent mind maps.
  * Consolidated validation: non-empty, unique IDs, descriptive labels with word limits, full coverage, connectivity without loops.
  * Enforced language consistency and explicit storage of node descriptions.
  * Expanded color guidance and branch color strategies, with root exceptions and edge color propagation.
  * Reintroduced roadmap ordering with per-child semantics and tighter JSON formatting for predictable output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->