### PR TITLE
refactor(convert): file size default limit up to 15MB.

### DIFF
--- a/src/services/convert/config/convert.config.ts
+++ b/src/services/convert/config/convert.config.ts
@@ -1,13 +1,15 @@
 import path from 'node:path';
 import { LaunchOptions } from 'puppeteer';
 
+const convertToMB = (byte: number): number => byte * 1024 * 1024;
+
 /**
  * Configuration constants for file conversion
  */
 export const CONVERT_CONFIG = {
     UPLOAD_DIR: process.env.UPLOAD_CONVERT_FILE_DIR || path.join(process.cwd(), 'uploads/convert'),
     OUTPUT_DIR: process.env.OUTPUT_CONVERT_FILE_DIR || path.join(process.cwd(), 'outputs/convert'),
-    MAX_FILE_SIZE: 10 * 1024 * 1024, // 10MB
+    MAX_FILE_SIZE: convertToMB(15), // 15MB
     GOTENBERG_URL: process.env.GOTENBERG_URL,
     SUPPORTED_EXTENSIONS: ['.txt', '.docx', '.doc'],
     PDF_OPTIONS: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased maximum file upload size limit from 10MB to 15MB.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->