### PR TITLE
Feature/media transcription: Add allowed mime types for video files, rename audio transcription route

### DIFF
--- a/src/features/audio-transcription/audio.middleware.ts
+++ b/src/features/audio-transcription/audio.middleware.ts
@@ -3,12 +3,12 @@ import { NextFunction, Request, Response } from 'express';
 
 class AudioMiddleware {
     public validateAudioSizeLimit(req: Request, res: Response, next: NextFunction) {
-        validateFileSize(req.file, { maxMb: 15 });
+        validateFileSize(req.file, { maxMb: 20 });
         next();
     }
 
     public validateAudioMimeType(req: Request, res: Response, next: NextFunction) {
-        validateFileMimeTypes(req.file, { mimeTypes: ['audio/mpeg'] });
+        validateFileMimeTypes(req.file, { mimeTypes: ['audio/mpeg', 'audio/wav', 'video/mp4'] });
         next();
     }
 }

--- a/src/features/whisper/api/whisper.service.ts
+++ b/src/features/whisper/api/whisper.service.ts
@@ -39,7 +39,7 @@ class WhisperService {
             formData.append('response_format', 'srt');
             const response = await axios.post(this.whisperInferenceUrl, formData, {
                 headers: formData.getHeaders(),
-                timeout: 120_000,
+                timeout: 300_000,
             });
             const transcriptWithTimestamps = response.data;
             return transcriptWithTimestamps;

--- a/src/routes/api.routes.ts
+++ b/src/routes/api.routes.ts
@@ -53,7 +53,7 @@ import './comment/comment.routes';
 import './content/content.routes';
 import './embedding/embedding.route';
 import './image/image.routes';
-import './audioTranscription/audioTranscription.routes';
+import './mediaTranscription/mediaTranscription.routes';
 import './convert/convert.routes';
 
 // Apply global async handler to router

--- a/src/routes/mediaTranscription/mediaTranscription.routes.ts
+++ b/src/routes/mediaTranscription/mediaTranscription.routes.ts
@@ -14,10 +14,11 @@ router.use(authMiddleware);
 const validateAudioMiddleware = [audioMiddleware.validateAudioSizeLimit, audioMiddleware.validateAudioMimeType];
 router.post('/', fileUploadSingleMiddleware, ...validateAudioMiddleware, audioTranscriptionController.handleTranscribe);
 
-registerRoute('/v1/audio-transcription', router, {
-    description: 'API for getting transcription of audio file',
+registerRoute('/v1/media-transcription', router, {
+    description:
+        'API for getting transcription of media file. This route is currently using audioTranscription controller (would change in the future, after testing if media transcription is feasible in production).',
     version: 'v1',
     isEnabled: true,
 });
 
-export const audioTranscriptionRoutes = router;
+export const mediaTranscriptionRoutes = router;

--- a/src/services/uploads/files/upload.file.R2.service.ts
+++ b/src/services/uploads/files/upload.file.R2.service.ts
@@ -44,14 +44,31 @@ const DEFAULT_ALLOWED_MIME_TYPES = [
     'application/x-7z-compressed',
     'application/x-tar',
     'application/gzip',
-    // Media files
+    // Audio files
     'audio/mpeg',
+    'audio/wav',
+    // Video files
+    'video/mp4',
 ];
 
 /**
  * Default allowed file extensions
  */
-const DEFAULT_ALLOWED_EXTENSIONS = ['.pdf', '.doc', '.docx', '.txt', '.md', '.jpeg', '.png', '.jpg', '.mp3'];
+const DEFAULT_ALLOWED_EXTENSIONS = [
+    '.pdf',
+    '.doc',
+    '.docx',
+    '.txt',
+    '.md',
+    '.jpeg',
+    '.png',
+    '.jpg',
+    // Audio files
+    '.mp3',
+    '.wav',
+    // Video files
+    '.mp4',
+];
 
 /**
  * File upload configuration interface


### PR DESCRIPTION
PR này bao gồm:
- Thêm mimetypes cho video files (.mp4 only)
- rename audio transcription route thành video transcription route
Note:
- các files liên quan đến audio transcription chưa được rename (vì cần check xem lên prod thì transcribe media files xử lý như sao), tránh sau này rename lại

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Increased maximum file size limit from 15 MB to 20 MB
  * Expanded supported file formats to include MP3, WAV, and MP4 files
  * Improved processing reliability with extended timeout duration
  * Renamed transcription service to reflect broader media file support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->